### PR TITLE
Adding City Launch to the conference List

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Ongoing list of civic tech or gov tech events. Includes previous and past events
 ### March 
 
 + 2 [School of Data NYC](https://schoolofdata.nyc/) _New York City, NY, USA_
++ 10- 12 [City Launch San Diego](https://connectedcc.org/) _San Diego, CA, USA_
 + 19 - 20 [The Impacts of Civic Technology Conference (TICTeC)](https://tictec.mysociety.org/) _Paris, France_
 
 ### February


### PR DESCRIPTION
Add city launch for future tracking. The 2019 version is only a couple of days away.